### PR TITLE
update links to no longer point to wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Absolute beginner's guide to DE10-Nano
 
-To get started with the guide, please visit [the wiki](https://github.com/zangman/de10-nano/wiki).
+To get started with the guide, please begin [here](#getting-started).
 
 To just download the Debian or Arch Linux ARM (**NEW**) image for the DE10-Nano, please visit the [releases page](https://github.com/zangman/de10-nano/releases).
 

--- a/docs/Archlinux-ARM-Root-File-System.md
+++ b/docs/Archlinux-ARM-Root-File-System.md
@@ -12,7 +12,7 @@ Here we'll walk through the steps to creating an Archlinux ARM root filesystem. 
 
 One of the main differences with creating the Archlinux ARM rootfs is we need to create the SD Card image first, mount it and then create our rootfs. I'm not entirely sure why this is required, but I suspect the reason is to take care of the various mount points correctly i.e. `/proc`, `/dev` etc.
 
-In any case, to get started, we'll need to go through all the steps listed [here](https://github.com/zangman/de10-nano/wiki/Building-the-SD-Card-image) all the way up to copying the [kernel and device tree](https://github.com/zangman/de10-nano/wiki/Building-the-SD-Card-image#kernel-and-device-tree-partition-1) and jump back here for the rootfs.
+In any case, to get started, we'll need to go through all the steps listed [here](./Building-the-SD-Card-image.md) all the way up to copying the [kernel and device tree](./Building-the-SD-Card-image.md#kernel-and-device-tree-partition-1) and jump back here for the rootfs.
 
 ## Archlinux ARM RootFS Steps
 
@@ -244,7 +244,7 @@ sudo rm ext4/usr/bin/qemu-arm-static
 sudo umount ext4
 ```
 
-Now head back over to [this section](https://github.com/zangman/de10-nano/wiki/Building-the-SD-Card-image#cleanup) to continue the clean up and writing to SD Card.
+Now head back over to [this section](./Building-the-SD-Card-image.md#cleanup) to continue the clean up and writing to SD Card.
 
 ##
 

--- a/docs/Building-SoC-Design.md
+++ b/docs/Building-SoC-Design.md
@@ -219,9 +219,9 @@ Hit `Ctrl+S` to save and then double-click to build our design. This can take 10
 
 #### Convert file to `.rbf`
 
-The last step is to convert the file to `.rbf` format as explained [here](<https://github.com/zangman/de10-nano/wiki/Flash-FPGA-from-HPS-(running-Linux)#create-a-blink-design>).
+The last step is to convert the file to `.rbf` format as explained [here](./Flash-FPGA-from-HPS-running-Linux.md#create-a-blink-design).
 
-Once converted, you can program the FPGA either on [boot-up](https://github.com/zangman/de10-nano/wiki/Flash-FPGA-On-Boot-Up) or from [the HPS](<https://github.com/zangman/de10-nano/wiki/Flash-FPGA-from-HPS-(running-Linux)>). If you are programming it from the HPS, then remember that the FPGA will get wiped when you power down the board. If this is a problem for you then the boot-up method might be preferable. The GHRD includes a module that will cause one of the LEDs to blink continuously. If you see this, congratulations, your design is up and running.
+Once converted, you can program the FPGA either on [boot-up](./Flash-FPGA-On-Boot-Up.md) or from [the HPS](./Flash-FPGA-from-HPS-running-Linux.md). If you are programming it from the HPS, then remember that the FPGA will get wiped when you power down the board. If this is a problem for you then the boot-up method might be preferable. The GHRD includes a module that will cause one of the LEDs to blink continuously. If you see this, congratulations, your design is up and running.
 
 ### Program to interact between the HPS and the FPGA
 
@@ -320,7 +320,7 @@ int main(int argc, char ** argv)
 
 Hang on! We don't have the header file `hps_0.h`. This header file contains all the memory addresses that we need for our leds.
 
-Once quartus completes synthesis, it would have created a file called `soc_system.sopcinfo` which contains all the address information. The Embedded Development Suite that we installed in the beginning includes a utility that will help generate our header file. Run the following commands to generate the header file. Note that this requires you to have correctly set up the [development environment](https://github.com/zangman/de10-nano/wiki/Setting-up-the-Development-Environment) along with the paths, otherwise they won't work.
+Once quartus completes synthesis, it would have created a file called `soc_system.sopcinfo` which contains all the address information. The Embedded Development Suite that we installed in the beginning includes a utility that will help generate our header file. Run the following commands to generate the header file. Note that this requires you to have correctly set up the [development environment](./Setting-up-the-Development-Environment.md) along with the paths, otherwise they won't work.
 
 ```bash
 cd $DEWD/DE10_NANO_SoC_GHRD

--- a/docs/Building-the-Kernel.md
+++ b/docs/Building-the-Kernel.md
@@ -90,7 +90,7 @@ Feel free to look through the other options and when done, press the right-arrow
 
 #### (Optional) Enable options for WIFI
 
-You can set up the necessary options needed for WIFI as explained [here](https://github.com/zangman/de10-nano/wiki/%5BOptional%5D-Setting-up-Wifi#compile-the-kernel-driver). This can be done later as well.
+You can set up the necessary options needed for WIFI as explained [here](./%5BOptional%5D-Setting-up-Wifi.md). This can be done later as well.
 
 ### Build the Kernel image
 

--- a/docs/Building-the-SD-Card-image.md
+++ b/docs/Building-the-SD-Card-image.md
@@ -311,7 +311,7 @@ sudo umount fat
 
 #### Root Filesystem partition
 
-> Note: If your rootfs is Archlinux ARM, then jump to [this section](https://github.com/zangman/de10-nano/wiki/Archlinux-ARM-Root-File-System) to continue with the rootfs setup instead of the steps below.
+> Note: If your rootfs is Archlinux ARM, then jump to [this section](./Archlinux-ARM-Root-File-System.md) to continue with the rootfs setup instead of the steps below.
 
 For the final partition, here are the steps:
 

--- a/docs/Creating-a-Bootscript.md
+++ b/docs/Creating-a-Bootscript.md
@@ -10,7 +10,7 @@ If you need to run some additional commands at boot time, instead of updating `b
 
 ## Pre-requisites
 
-You will require U-Boot sources available as described in the [Building U-Boot](<https://github.com/zangman/de10-nano/wiki/Building-the-Universal-Bootloader-(U-Boot)#configure-u-boot-to-flash-fpga-automatically-at-boot-time>) section. [This section](<https://github.com/zangman/de10-nano/wiki/Building-the-Universal-Bootloader-(U-Boot)#configure-u-boot-to-flash-fpga-automatically-at-boot-time>) shows how to modify `bootcmd` to check for a bootscript and you will need to have followed the same/similar steps when setting up U-Boot for your device.
+You will require U-Boot sources available as described in the [Building U-Boot](./Building-the-Universal-Bootloader-U-Boot.md#configure-u-boot-to-flash-fpga-automatically-at-boot-time) section. [This section](./Building-the-Universal-Bootloader-U-Boot.md#configure-u-boot-to-flash-fpga-automatically-at-boot-time) shows how to modify `bootcmd` to check for a bootscript and you will need to have followed the same/similar steps when setting up U-Boot for your device.
 
 ## Steps
 

--- a/docs/Debian-Root-File-System.md
+++ b/docs/Debian-Root-File-System.md
@@ -170,7 +170,7 @@ While still in the `chroot` environment, let's do some setup so that our rootfs 
 
 ## (Optional) Setup WIFI
 
-You can also do the necessary steps for setting up WIFI as detailed [here](https://github.com/zangman/de10-nano/wiki/%5BOptional%5D-Setting-up-Wifi#install-the-necessary-firmware). This is optional and can be done later on also if you can connect your de10-nano to the LAN.
+You can also do the necessary steps for setting up WIFI as detailed [here](./%5BOptional%5D-Setting-up-Wifi.md#install-the-necessary-firmware). This is optional and can be done later on also if you can connect your de10-nano to the LAN.
 
 ## Clean up
 

--- a/docs/FPGA-SDRAM-Communication_-Avalon-MM-Agent-Slave-Trigger-Component.md
+++ b/docs/FPGA-SDRAM-Communication_-Avalon-MM-Agent-Slave-Trigger-Component.md
@@ -25,7 +25,7 @@ The image below shows the general approach:
 
 ## Trigger Component
 
-We will need a trigger component that will initiate the read transaction. This will utilise the HPS-FPGA bridge in a similar way as was explained in the [Simple Adder](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-Custom-Avalon-MM-Components) project.
+We will need a trigger component that will initiate the read transaction. This will utilise the HPS-FPGA bridge in a similar way as was explained in the [Simple Adder](./Simple-Hardware-Adder_-Custom-Avalon-MM-Components.md) project.
 
 But the difference is that we only need send a boolean value i.e. "Begin transaction". We don't really care about the data. So this will be an Avalon Agent component and we'll just use the `write` signal.
 

--- a/docs/FPGA-SDRAM-Communication_-Avalon-MM-Host-Master-Component-Part-1.md
+++ b/docs/FPGA-SDRAM-Communication_-Avalon-MM-Host-Master-Component-Part-1.md
@@ -12,7 +12,7 @@ For a beginner, this is quite complicated. So, to make it easier to follow, I've
 
 ## State Machine
 
-From the section on the [Avalon MM Read and Write interfaces](https://github.com/zangman/de10-nano/wiki/FPGA-SDRAM-Communication:-More-about-the-Avalon-Memory-Mapped-Interface#avalon-mm-bidirectional-port-signals-for-sdram-controller), it is quite obvious that we need to implement a state machine. For a read transaction, I can think of three different states:
+From the section on the [Avalon MM Read and Write interfaces](./FPGA-SDRAM-Communication_-More-about-the-Avalon-Memory-Mapped-Interface.md#avalon-mm-bidirectional-port-signals-for-sdram-controller), it is quite obvious that we need to implement a state machine. For a read transaction, I can think of three different states:
 
 1. **INIT** - When we're idle and ready to start a transaction.
 2. **READ_START** - When we're initiated the read transaction and waiting for the `waitrequest` to be de-asserted.

--- a/docs/FPGA-SDRAM-Communication_-Avalon-MM-Host-Master-Component-Part-2.md
+++ b/docs/FPGA-SDRAM-Communication_-Avalon-MM-Host-Master-Component-Part-2.md
@@ -1,6 +1,7 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+**Table of Contents** _generated with [DocToc](https://github.com/thlorenz/doctoc)_
 
 - [Summary](#summary)
 - [Building the project](#building-the-project)
@@ -21,7 +22,7 @@ Here we will go through the steps of setting the host component up in Platform D
 
 ### Initial setup
 
-We will use a copy of the `ghrd_barebones_template` that we created over [here](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-Initial-Project-Setup#create-a-backup-of-this-project). If you don't have it, follow the steps as shown on [this page](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-Initial-Project-Setup) to have a clean initial project to start with.
+We will use a copy of the `ghrd_barebones_template` that we created over [here](./Simple-Hardware-Adder_-Initial-Project-Setup.md#create-a-backup-of-this-project). If you don't have it, follow the steps as shown on [this page](./Simple-Hardware-Adder_-Initial-Project-Setup.md) to have a clean initial project to start with.
 
 Make a copy of the template first:
 
@@ -42,7 +43,7 @@ Right click on `hps_0` and select `Edit...`. Make sure the options are as shown 
 
 ### New component - Avalon Control
 
-This is the trigger component that we created earlier. We'll call it `avalon_control` and we'll create a new agent component. I won't go into great detail in creating this as it's already explained in the [Simple Adder](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-Custom-Avalon-MM-Components) project. Here is a screenshot that shows what the signals tab looks like:
+This is the trigger component that we created earlier. We'll call it `avalon_control` and we'll create a new agent component. I won't go into great detail in creating this as it's already explained in the [Simple Adder](./Simple-Hardware-Adder_-Custom-Avalon-MM-Components.md) project. Here is a screenshot that shows what the signals tab looks like:
 
 ![](images/avalon_control.png)
 
@@ -84,8 +85,6 @@ Once the compilation succeeds, go to `File > Convert Programming Files` as shown
 
 ![](images/convert_rbf.png)
 
-
-
-Normally we would have flashed the design as explained [here](https://github.com/zangman/de10-nano/wiki/Flash-FPGA-from-HPS-(running-Linux)) and [here](https://github.com/zangman/de10-nano/wiki/Flash-FPGA-On-Boot-Up). But in this case, we need to set some registers on the HPS otherwise the HPS will hang as soon as we try to read.
+Normally we would have flashed the design as explained [here](./Flash-FPGA-from-HPS-running-Linux.md) and [here](./Flash-FPGA-On-Boot-Up.md). But in this case, we need to set some registers on the HPS otherwise the HPS will hang as soon as we try to read.
 
 Let's cover this in the next section.

--- a/docs/FPGA-SDRAM-Communication_-Avalon-MM-Host-Master-Component-Part-3.md
+++ b/docs/FPGA-SDRAM-Communication_-Avalon-MM-Host-Master-Component-Part-3.md
@@ -111,9 +111,9 @@ What we need to do is:
 
 **NOTE**: If these steps aren't done exactly as explained here, the HPS will hang when the FPGA tries to access SDRAM.
 
-This needs to be done only once when powering it up for the first time. You can then proceed to flash any new designs [without rebooting](<https://github.com/zangman/de10-nano/wiki/Flash-FPGA-from-HPS-(running-Linux)>) even for designs that access the SDRAM. But if you power down the device (not reboot), you will need to go through the steps again.
+This needs to be done only once when powering it up for the first time. You can then proceed to flash any new designs [without rebooting](./Flash-FPGA-from-HPS-running-Linux.md) even for designs that access the SDRAM. But if you power down the device (not reboot), you will need to go through the steps again.
 
-To avoid doing this repeatedly, you can [create a bootscript](https://github.com/zangman/de10-nano/wiki/Creating-a-Bootscript) which will make it less tedious.
+To avoid doing this repeatedly, you can [create a bootscript](./Creating-a-Bootscript.md) which will make it less tedious.
 
 ## Trying out our design
 

--- a/docs/FPGA-SDRAM-Communication_-Introduction.md
+++ b/docs/FPGA-SDRAM-Communication_-Introduction.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-If you haven't done it already, I would recommend working on the [Simple Hardware Adder](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-Introduction) project first before attempting this one. That project covers a lot of introductory concepts such Platform Designer, Avalon Slaves, memory addressing etc. which we'll build upon in this project.
+If you haven't done it already, I would recommend working on the [Simple Hardware Adder](./Simple-Hardware-Adder_-Introduction.md) project first before attempting this one. That project covers a lot of introductory concepts such Platform Designer, Avalon Slaves, memory addressing etc. which we'll build upon in this project.
 
 In this project, we'll up the game quite a bit and introduce several new concepts and techniques. These include:
 

--- a/docs/FPGA-SDRAM-Communication_-More-about-the-Avalon-Memory-Mapped-Interface.md
+++ b/docs/FPGA-SDRAM-Communication_-More-about-the-Avalon-Memory-Mapped-Interface.md
@@ -6,17 +6,17 @@
 
 ## Summary
 
-This is a follow up to the [Primer on Avalon MM](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-Primer-on-Avalon-Memory-Map-Interface). If you haven't read that, please take a quick scan and then continue on this page. Here we talk a little bit about the different types of Avalon MM transactions.
+This is a follow up to the [Primer on Avalon MM](./Simple-Hardware-Adder_-Primer-on-Avalon-Memory-Map-Interface.md). If you haven't read that, please take a quick scan and then continue on this page. Here we talk a little bit about the different types of Avalon MM transactions.
 
 ## Avalon MM Transactions
 
 Avalon is a fairly comprehensive bus architecture. The kinds of transactions that one can do with Avalon are wide and varied. As you try to get more efficient with your transactions (Ex: get more throughput), the complexity of the transaction increases. The complexity also increases if you are writing a Host (Master) component versus an Agent (Slave) component. While an agent just has to respond to whatever responses are being made by a host, the host on the other hand has to not only respond to the agent's responses but also manage the bus to make sure the agent receives the instructions correctly.
 
-In the [Simple Hardware Adder](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-Custom-Avalon-MM-Components) we had created agent components. This was because there was already a host provided by the HPS-FPGA bridge. But for the SDRAM controller, since there is no host, we will need to develop our own host component.
+In the [Simple Hardware Adder](./Simple-Hardware-Adder_-Custom-Avalon-MM-Components.md) we had created agent components. This was because there was already a host provided by the HPS-FPGA bridge. But for the SDRAM controller, since there is no host, we will need to develop our own host component.
 
 But before that, let's walk through a few simple transaction types with commonly used signals. The HPS SDRAM controller uses the **Avalon MM Burst Interface**. So it is necessary for us to understand how this is implemented if we wish to design our own custom host component. The Burst interface builds upon the Pipelined interface which builds upon the basic read/write interface. Which is why we cover all three below.
 
-The content below is mostly sourced from this [9 minute video](https://www.youtube.com/watch?v=8GAqT3nzHeQ). I strongly recommend watching this one, it was a lightbulb moment for me. Below, I will try and expand a bit more over what the video covers. But if everything in the video makes sense to you, feel free to just skip to the [last section](https://github.com/zangman/de10-nano/wiki/FPGA-SDRAM-Communication:-More-about-the-Avalon-Memory-Mapped-Interface#avalon-mm-bidirectional-port-signals-for-sdram-controller) which shows the ports required for the host component.
+The content below is mostly sourced from this [9 minute video](https://www.youtube.com/watch?v=8GAqT3nzHeQ). I strongly recommend watching this one, it was a lightbulb moment for me. Below, I will try and expand a bit more over what the video covers. But if everything in the video makes sense to you, feel free to just skip to the [last section](./FPGA-SDRAM-Communication_-More-about-the-Avalon-Memory-Mapped-Interface.md#avalon-mm-bidirectional-port-signals-for-sdram-controller) which shows the ports required for the host component.
 
 ### Basic Avalon MM Read/Write
 

--- a/docs/Flash-FPGA-On-Boot-Up.md
+++ b/docs/Flash-FPGA-On-Boot-Up.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Flashing the FPGA on boot up is a convenient way to have your design on the FPGA every time the board powers up. Here we will go through the steps to do it. Make sure you've followed the step to [modify the U-Boot to flash the FPGA](<https://github.com/zangman/de10-nano/wiki/Building-the-Universal-Bootloader-(U-Boot)#part-1---customizing-the-bootloader-for-the-de10-nano>), without this, it will not work.
+Flashing the FPGA on boot up is a convenient way to have your design on the FPGA every time the board powers up. Here we will go through the steps to do it. Make sure you've followed the step to [modify the U-Boot to flash the FPGA](./Building-the-Universal-Bootloader-U-Boot.md#part-1---customizing-the-bootloader-for-the-de10-nano), without this, it will not work.
 
 ## Steps
 
@@ -14,8 +14,8 @@ Flashing the FPGA on boot up is a convenient way to have your design on the FPGA
 
 Complete the following steps to generate the `.rbf` file:
 
-- [Set the MSEL pins](<https://github.com/zangman/de10-nano/wiki/Flash-FPGA-from-HPS-(running-Linux)#set-the-msel-pins>)
-- [Create a blink design](<https://github.com/zangman/de10-nano/wiki/Flash-FPGA-from-HPS-(running-Linux)#create-a-blink-design>)
+- [Set the MSEL pins](./Flash-FPGA-from-HPS-running-Linux.md#set-the-msel-pins)
+- [Create a blink design](./Flash-FPGA-from-HPS-running-Linux.md#create-a-blink-design)
 
 ### Copy the RBF file into the FAT partition
 

--- a/docs/Simple-Hardware-Adder_-Initial-Project-Setup.md
+++ b/docs/Simple-Hardware-Adder_-Initial-Project-Setup.md
@@ -12,7 +12,6 @@ We're going to create a template project and save it so that we can reuse it for
 
 Complete the following steps explained at the links below and proceed to the next section when done:
 
-1. [Download the CD-ROM](Building-SoC-Design.md#download-the-cd-rom)
 2. [Copy the GHRD to the working directory](Building-SoC-Design.md#copy-the-ghrd-to-working-directory)
 
 ## Upgrade the IP to current quartus version

--- a/docs/Simple-Hardware-Adder_-Initial-Project-Setup.md
+++ b/docs/Simple-Hardware-Adder_-Initial-Project-Setup.md
@@ -12,7 +12,8 @@ We're going to create a template project and save it so that we can reuse it for
 
 Complete the following steps explained at the links below and proceed to the next section when done:
 
-2. [Copy the GHRD to the working directory](Building-SoC-Design.md#copy-the-ghrd-to-working-directory)
+1. [Download the CD-ROM](./Building-SoC-Design.md#download-the-cd-rom)
+2. [Copy the GHRD to the working directory](./Building-SoC-Design.md#copy-the-ghrd-to-working-directory)
 
 ## Upgrade the IP to current quartus version
 

--- a/docs/Simple-Hardware-Adder_-Setting-up-the-Adder.md
+++ b/docs/Simple-Hardware-Adder_-Setting-up-the-Adder.md
@@ -164,11 +164,11 @@ Before we can start using any of the bridges, we'll need to enable them in the d
 cat /sys/class/fpga_bridge/*/state
 ```
 
-If they're `disabled` or you get an error then go through the steps described [here](https://github.com/zangman/de10-nano/wiki/Configuring-the-Device-Tree) and verify that the bridges are all enabled as shown on the same page.
+If they're `disabled` or you get an error then go through the steps described [here](./Configuring-the-Device-Tree.md) and verify that the bridges are all enabled as shown on the same page.
 
 ## Flashing the design
 
-Now we can flash our design on the de10-nano. This has already been covered [here](<https://github.com/zangman/de10-nano/wiki/Flash-FPGA-from-HPS-(running-Linux)>) and [here](https://github.com/zangman/de10-nano/wiki/Flash-FPGA-On-Boot-Up), so I won't be going into it here. You can use either method to flash the FPGA.
+Now we can flash our design on the de10-nano. This has already been covered [here](./Flash-FPGA-from-HPS-running-Linux.md) and [here](./Flash-FPGA-On-Boot-Up.md), so I won't be going into it here. You can use either method to flash the FPGA.
 
 Once your design has been successfully flashed and you can see the blinking LED to indicate it is ready, we can now proceed to writing the software to use our hardware adder.
 

--- a/docs/Simple-Hardware-Adder_-Setting-up-the-Adder.md
+++ b/docs/Simple-Hardware-Adder_-Setting-up-the-Adder.md
@@ -158,7 +158,7 @@ Double click the `Assembler` in the left side menu and let the compilation compl
 
 ## Configuring the Device Tree
 
-Before we can start using any of the bridges, we'll need to enable them in the device tree. This is covered over [here](https://github.com/zangman/de10-nano/wiki/Configuring-the-Device-Tree) so I won't be going into it again. In the de10-nano, check that the bridges are enabled with the following command.
+Before we can start using any of the bridges, we'll need to enable them in the device tree. This is covered over [here](./Configuring-the-Device-Tree.md) so I won't be going into it again. In the de10-nano, check that the bridges are enabled with the following command.
 
 ```bash
 cat /sys/class/fpga_bridge/*/state

--- a/docs/Simple-Hardware-Adder_-Writing-the-Software.md
+++ b/docs/Simple-Hardware-Adder_-Writing-the-Software.md
@@ -20,7 +20,7 @@ We'll write an application program in `C`. There are 2 ways to write this progra
    gcc myprog.c -o myprog
    ```
 
-2. **Writing on a host machine and copying the executable** - This is my preferred approach. We basically write the program on a different machine, which in my case is Debian running on virtualbox. Then we compile it using the ARM cross-compiler that we downloaded and set up the path in [this section](https://github.com/zangman/de10-nano/wiki/Setting-up-the-Development-Environment#arm-compiler). Using this approach, the command line to compile it is:
+2. **Writing on a host machine and copying the executable** - This is my preferred approach. We basically write the program on a different machine, which in my case is Debian running on virtualbox. Then we compile it using the ARM cross-compiler that we downloaded and set up the path in [this section](./Setting-up-the-Development-Environment.md#arm-compiler). Using this approach, the command line to compile it is:
 
    ```bash
    ${CROSS_COMPILE}gcc myprog.c -o myprog
@@ -397,7 +397,7 @@ Unfortunately, this happens quite often and the bad news is, there is no easy wa
 
 7. Check the verilog and C code with the reference source code if there are any mistakes.
 
-8. Make sure the `MSEL` pins are all set to `ON` as described [here](<https://github.com/zangman/de10-nano/wiki/Flash-FPGA-from-HPS-(running-Linux)#set-the-msel-pins>).
+8. Make sure the `MSEL` pins are all set to `ON` as described [here](./Flash-FPGA-from-HPS-running-Linux.md#set-the-msel-pins).
 
 If unable to find the problem, maybe it's better to just start over again. I've done this countless times and it is the price to pay for learning.
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,48 +1,55 @@
 # Contents
 
 ## Getting Started
- * [Introduction to SoCs](https://github.com/zangman/de10-nano/wiki/Introduction-to-SoCs)
- * [Introduction to DE10-Nano](https://github.com/zangman/de10-nano/wiki/Introduction-to-DE10-Nano)
- * [Setting up the development environment](https://github.com/zangman/de10-nano/wiki/Setting-up-the-Development-Environment)
+
+- [Introduction to SoCs](./Introduction-to-SoCs.md)
+- [Introduction to DE10-Nano](./Introduction-to-DE10-Nano.md)
+- [Setting up the development environment](./Setting-up-the-Development-Environment.md)
 
 ## Building Embedded Linux - Full Custom
- * [The Basics](https://github.com/zangman/de10-nano/wiki/Building-Embedded-Linux)
- * [Building the Universal Bootloader (U-Boot)](https://github.com/zangman/de10-nano/wiki/Building-the-Universal-Bootloader-(U-Boot))
- * [Building the Kernel](https://github.com/zangman/de10-nano/wiki/Building-the-Kernel)
- *  RootFS - Choose one:
-     * [Debian](https://github.com/zangman/de10-nano/wiki/Debian-Root-File-System)
-     * [Archlinux ARM](https://github.com/zangman/de10-nano/wiki/Archlinux-ARM-Root-File-System)
- * [Creating the SD Card Image](https://github.com/zangman/de10-nano/wiki/Building-the-SD-Card-image)
- * [(Optional) Setting up WIFI](https://github.com/zangman/de10-nano/wiki/%5BOptional%5D-Setting-up-Wifi)
+
+- [The Basics](./Building-Embedded-Linux.md)
+- [Building the Universal Bootloader (U-Boot)](./Building-the-Universal-Bootloader-U-Boot.md)
+- [Building the Kernel](./Building-the-Kernel.md)
+- RootFS - Choose one:
+  - [Debian](./Debian-Root-File-System.md))
+  - [Archlinux ARM](./Archlinux-ARM-Root-File-System.md)
+- [Creating the SD Card Image](./Building-the-SD-Card-image.md)
+- [(Optional) Setting up WIFI](./%5BOptional%5D-Setting-up-Wifi.md)
 
 ## Flashing the FPGA from SD Card
-   * [From Linux](https://github.com/zangman/de10-nano/wiki/Flash-FPGA-from-HPS-(running-Linux))
-   * [On Boot Up](https://github.com/zangman/de10-nano/wiki/Flash-FPGA-On-Boot-Up)
+
+- [From Linux](./Flash-FPGA-from-HPS-running-Linux.md)
+- [On Boot Up](./Flash-FPGA-On-Boot-Up.md)
 
 ## HPS and FPGA communication
- * [Configuring the Device Tree](https://github.com/zangman/de10-nano/wiki/Configuring-the-Device-Tree)
- * [Designing and Flashing the design](https://github.com/zangman/de10-nano/wiki/Building-SoC-Design)
+
+- [Configuring the Device Tree](./Configuring-the-Device-Tree.md)
+- [Designing and Flashing the design](./Building-SoC-Design.md)
 
 ## My First SoC - Simple Hardware Adder
- * [Introduction](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-Introduction)
- * [Initial project setup](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-Initial-Project-Setup)
- * [Simple Adder](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-The-Adder)
- * [Primer on Avalon MM](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-Primer-on-Avalon-Memory-Map-Interface)
- * [Custom Avalon MM Components](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-Custom-Avalon-MM-Components)
- * [Wiring the Components](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-Wiring-the-components)
- * [Add the Simple Adder](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-Setting-up-the-Adder)
- * [Writing the Software](https://github.com/zangman/de10-nano/wiki/Simple-Hardware-Adder:-Writing-the-Software)
+
+- [Introduction](./Simple-Hardware-Adder_-Introduction.md)
+- [Initial project setup](./Simple-Hardware-Adder_-Initial-Project-Setup.md)
+- [Simple Adder](./Simple-Hardware-Adder_-The-Adder.md)
+- [Primer on Avalon MM](./Simple-Hardware-Adder_-Primer-on-Avalon-Memory-Map-Interface.md)
+- [Custom Avalon MM Components](./Simple-Hardware-Adder_-Custom-Avalon-MM-Components.md)
+- [Wiring the Components](./Simple-Hardware-Adder_-Wiring-the-components.md)
+- [Add the Simple Adder](./Simple-Hardware-Adder_-Setting-up-the-Adder.md)
+- [Writing the Software](./Simple-Hardware-Adder_-Writing-the-Software.md)
 
 ## FPGA - SDRAM Communication
- * [Introduction](https://github.com/zangman/de10-nano/wiki/FPGA-SDRAM-Communication:-Introduction)
- * [SDRAM Controller](https://github.com/zangman/de10-nano/wiki/FPGA-SDRAM-Communication:-SDRAM-Controller)
- * [More on Avalon MM](https://github.com/zangman/de10-nano/wiki/FPGA-SDRAM-Communication:-More-about-the-Avalon-Memory-Mapped-Interface)
- * [Avalon MM Agent/Slave - Trigger Component](https://github.com/zangman/de10-nano/wiki/FPGA-SDRAM-Communication:-Avalon-MM-Agent-Slave-Trigger-Component)
- * [Avalon MM Host/Master - 1](https://github.com/zangman/de10-nano/wiki/FPGA-SDRAM-Communication:-Avalon-MM-Host-Master-Component-Part-1)
- * [Avalon MM Host/Master - 2](https://github.com/zangman/de10-nano/wiki/FPGA-SDRAM-Communication:-Avalon-MM-Host-Master-Component-Part-2)
- * [Avalon MM Host/Master - 3](https://github.com/zangman/de10-nano/wiki/FPGA-SDRAM-Communication:-Avalon-MM-Host-Master-Component-Part-3)
+
+- [Introduction](./FPGA-SDRAM-Communication_-Introduction.md)
+- [SDRAM Controller](./FPGA-SDRAM-Communication_-SDRAM-Controller.md)
+- [More on Avalon MM](./FPGA-SDRAM-Communication_-More-about-the-Avalon-Memory-Mapped-Interface.md)
+- [Avalon MM Agent/Slave - Trigger Component](./FPGA-SDRAM-Communication_-Avalon-MM-Agent-Slave-Trigger-Component.md)
+- [Avalon MM Host/Master - 1](./FPGA-SDRAM-Communication_-Avalon-MM-Host-Master-Component-Part-1.md)
+- [Avalon MM Host/Master - 2](./FPGA-SDRAM-Communication_-Avalon-MM-Host-Master-Component-Part-2.md)
+- [Avalon MM Host/Master - 3](./FPGA-SDRAM-Communication_-Avalon-MM-Host-Master-Component-Part-3.md)
 
 ## Appendix
- * [Yocto Linux](https://github.com/zangman/de10-nano/wiki/Yocto-Linux)
- * [SSH Without Password](https://github.com/zangman/de10-nano/wiki/SSH-Without-Password)
- * [Creating a bootscript](https://github.com/zangman/de10-nano/wiki/Creating-a-Bootscript)
+
+- [Yocto Linux](./Yocto-Linux.md)
+- [SSH Without Password](./SSH-Without-Password.md)
+- [Creating a bootscript](./Creating-a-Bootscript.md)


### PR DESCRIPTION
This is a follow-up to #12 where it was discovered there are still links that point back to the wiki pages.

All links should now point to the correct page within the docs folder.